### PR TITLE
Fix fragment delete to use filter-based DeleteRelationships RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `memory_forget` now uses filter-based `DeleteRelationships` RPC to clean up SpiceDB relationships, fixing orphaned tuples when deleting fragments stored to non-default groups or by other subjects
+
 ## 0.1.2 - 2026-02-09
 
 ### Added

--- a/authorization.ts
+++ b/authorization.ts
@@ -107,43 +107,16 @@ export async function writeFragmentRelationships(
 
 /**
  * Remove all authorization relationships for a memory fragment.
- * Called when deleting a memory.
+ * Uses filter-based deletion — no need to know the group, sharer, or involved parties.
  */
 export async function deleteFragmentRelationships(
   spicedb: SpiceDbClient,
   fragmentId: string,
-  params: FragmentRelationships,
-): Promise<void> {
-  const tuples: RelationshipTuple[] = [
-    {
-      resourceType: "memory_fragment",
-      resourceId: fragmentId,
-      relation: "source_group",
-      subjectType: "group",
-      subjectId: params.groupId,
-    },
-    {
-      resourceType: "memory_fragment",
-      resourceId: fragmentId,
-      relation: "shared_by",
-      subjectType: params.sharedBy.type,
-      subjectId: params.sharedBy.id,
-    },
-  ];
-
-  if (params.involves) {
-    for (const person of params.involves) {
-      tuples.push({
-        resourceType: "memory_fragment",
-        resourceId: fragmentId,
-        relation: "involves",
-        subjectType: person.type,
-        subjectId: person.id,
-      });
-    }
-  }
-
-  await spicedb.deleteRelationships(tuples);
+): Promise<string | undefined> {
+  return spicedb.deleteRelationshipsByFilter({
+    resourceType: "memory_fragment",
+    resourceId: fragmentId,
+  });
 }
 
 /**

--- a/e2e.test.ts
+++ b/e2e.test.ts
@@ -396,11 +396,7 @@ describeLive("e2e: Graphiti + SpiceDB integration", () => {
     await graphiti.deleteEpisode(episodeId);
 
     // Clean up SpiceDB relationships
-    await deleteFragmentRelationships(spicedb, episodeId, {
-      fragmentId: episodeId,
-      groupId: TEST_GROUP,
-      sharedBy: agentSubject,
-    });
+    await deleteFragmentRelationships(spicedb, episodeId);
 
     // Remove from cleanup list since we already deleted it
     const idx = createdEpisodeIds.indexOf(episodeId);

--- a/index.test.ts
+++ b/index.test.ts
@@ -13,6 +13,7 @@ vi.mock("@authzed/authzed-node", () => {
     writeSchema: vi.fn().mockResolvedValue({}),
     readSchema: vi.fn().mockResolvedValue({ schemaText: "" }),
     writeRelationships: vi.fn().mockResolvedValue({}),
+    deleteRelationships: vi.fn().mockResolvedValue({ deletedAt: { token: "delete-token" } }),
     checkPermission: vi.fn().mockResolvedValue({
       permissionship: 2, // HAS_PERMISSION
     }),
@@ -30,6 +31,8 @@ vi.mock("@authzed/authzed-node", () => {
       WriteSchemaRequest: { create: vi.fn((v: unknown) => v) },
       ReadSchemaRequest: { create: vi.fn((v: unknown) => v) },
       WriteRelationshipsRequest: { create: vi.fn((v: unknown) => v) },
+      DeleteRelationshipsRequest: { create: vi.fn((v: unknown) => v) },
+      RelationshipFilter: { create: vi.fn((v: unknown) => v) },
       CheckPermissionRequest: { create: vi.fn((v: unknown) => v) },
       CheckPermissionResponse_Permissionship: { HAS_PERMISSION: 2 },
       LookupResourcesRequest: { create: vi.fn((v: unknown) => v) },
@@ -142,6 +145,7 @@ describe("memory-graphiti plugin", () => {
     const mockClient = (v1.NewClient as ReturnType<typeof vi.fn>)();
     mockClient.promises.checkPermission.mockResolvedValue({ permissionship: 2 });
     mockClient.promises.lookupResources.mockResolvedValue([{ resourceObjectId: "main" }]);
+    mockClient.promises.deleteRelationships.mockResolvedValue({ deletedAt: { token: "delete-token" } });
 
     mockApi = {
       id: "memory-graphiti",

--- a/index.ts
+++ b/index.ts
@@ -341,11 +341,7 @@ const memoryGraphitiPlugin = {
 
           // 3. Clean up SpiceDB relationships (best-effort)
           try {
-            await deleteFragmentRelationships(spicedb, episode_id, {
-              fragmentId: episode_id,
-              groupId: cfg.graphiti.defaultGroupId,
-              sharedBy: currentSubject,
-            });
+            await deleteFragmentRelationships(spicedb, episode_id);
           } catch {
             api.logger.warn(
               `memory-graphiti: failed to clean up SpiceDB relationships for ${episode_id}`,

--- a/spicedb.ts
+++ b/spicedb.ts
@@ -2,7 +2,7 @@
  * SpiceDB Client Wrapper
  *
  * Wraps @authzed/authzed-node for authorization operations:
- * WriteSchema, WriteRelationships, LookupResources, CheckPermission.
+ * WriteSchema, WriteRelationships, DeleteRelationships, LookupResources, CheckPermission.
  */
 
 import { v1 } from "@authzed/authzed-node";
@@ -111,6 +111,23 @@ export class SpiceDbClient {
 
     const request = v1.WriteRelationshipsRequest.create({ updates });
     await this.promises.writeRelationships(request);
+  }
+
+  async deleteRelationshipsByFilter(params: {
+    resourceType: string;
+    resourceId: string;
+    relation?: string;
+  }): Promise<string | undefined> {
+    const request = v1.DeleteRelationshipsRequest.create({
+      relationshipFilter: v1.RelationshipFilter.create({
+        resourceType: params.resourceType,
+        optionalResourceId: params.resourceId,
+        ...(params.relation ? { optionalRelation: params.relation } : {}),
+      }),
+    });
+
+    const response = await this.promises.deleteRelationships(request);
+    return response.deletedAt?.token;
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `deleteRelationshipsByFilter()` to `SpiceDbClient` using the `DeleteRelationships` RPC with `RelationshipFilter`, which deletes all relationships matching a resource type + ID without needing to reconstruct exact tuples
- Simplifies `deleteFragmentRelationships()` to a single filter-based call — no longer requires `groupId`, `sharedBy`, or `involves` parameters
- Fixes the `memory_forget` bug where cleanup was hardcoded to `defaultGroupId` and `currentSubject`, leaving orphaned SpiceDB tuples for fragments stored to non-default groups or by other subjects
- Returns `ZedToken` from the delete response for forward compatibility with #2

## Test plan

- [x] All 81 unit tests pass (`npx vitest run --exclude e2e.test.ts`)
- [x] E2E: store a memory to group "family", delete via `memory_forget` — verify no orphaned relationships
- [x] E2E: `OPENCLAW_LIVE_TEST=1 npx vitest run e2e.test.ts`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)