### PR TITLE
Add ZedToken consistency tuning for causal read-after-write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- ZedToken consistency tuning: SpiceDB reads after writes now use `at_least_as_fresh` consistency with the token from the preceding write, ensuring causal consistency without the cost of `fully_consistent`; reads without a prior write use `minimize_latency` for optimal performance
+
 ### Fixed
 
 - `memory_forget` now uses filter-based `DeleteRelationships` RPC to clean up SpiceDB relationships, fixing orphaned tuples when deleting fragments stored to non-default groups or by other subjects


### PR DESCRIPTION
## Summary

- Adds `ConsistencyMode` type and `buildConsistency()` helper to `SpiceDbClient`, with three modes: `fully_consistent`, `at_least_as_fresh(token)`, and `minimize_latency`
- Returns ZedTokens from `writeRelationships`, `ensureGroupMembership`, `writeFragmentRelationships`, and `deleteFragmentRelationships`
- Threads `lastWriteToken` through all authorization read call sites (`lookupAuthorizedGroups`, `canWriteToGroup`, `canDeleteFragment`) so reads after own writes use `at_least_as_fresh` consistency
- Default consistency changed from `fully_consistent` to `minimize_latency` — reads without a prior write no longer pay the full consistency cost

## Test plan

- [x] All 85 unit tests pass (`npx vitest run --exclude e2e.test.ts`)
- [x] All 13 e2e tests pass (`OPENCLAW_LIVE_TEST=1 npx vitest run e2e.test.ts`)
- [x] New test: verifies ZedToken is threaded from `memory_store` write to subsequent `memory_recall` read
- [x] New tests: verify `at_least_as_fresh` consistency passed when `zedToken` provided to authorization functions

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)