### PR TITLE
Fix plugin id mismatch in Graphiti MCP clientInfo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,11 +11,12 @@ Authorization is enforced at the data layer, not in prompts. Every read, write, 
 ## Quick Reference
 
 ```bash
-# Run unit tests (80 tests, no services required)
+# Run unit tests (85 tests, no services required)
 npx vitest run --exclude e2e.test.ts
 
 # Run e2e tests (13 tests, requires running services)
-OPENCLAW_LIVE_TEST=1 npx vitest run e2e.test.ts
+# Use OPENAI_API_KEY=1 as dummy value — Graphiti needs it set but the test doesn't call OpenAI directly
+OPENAI_API_KEY=1 OPENCLAW_LIVE_TEST=1 npx vitest run e2e.test.ts
 
 # Start infrastructure natively (dev container)
 ./scripts/dev-start.sh
@@ -36,7 +37,7 @@ openclaw graphiti-mem import --include-sessions  # + session transcripts
 | `index.ts` | Plugin entry point. Registers tools (`memory_recall`, `memory_store`, `memory_forget`, `memory_status`), lifecycle hooks (`before_agent_start` for auto-recall, `agent_end` for auto-capture), CLI commands (`graphiti-mem`), and the startup service. |
 | `config.ts` | Config schema, parsing, defaults, `${ENV_VAR}` interpolation. |
 | `graphiti.ts` | `GraphitiClient` — HTTP client for Graphiti MCP server. JSON-RPC 2.0 over SSE with MCP session lifecycle (initialize → tools/call → close). |
-| `spicedb.ts` | `SpiceDbClient` — gRPC wrapper around `@authzed/authzed-node`. WriteSchema, ReadSchema, WriteRelationships, DeleteRelationships, CheckPermission, LookupResources. |
+| `spicedb.ts` | `SpiceDbClient` — gRPC wrapper around `@authzed/authzed-node`. WriteSchema, ReadSchema, WriteRelationships, DeleteRelationships, DeleteRelationshipsByFilter, BulkImportRelationships, CheckPermission, LookupResources. All reads accept a `ConsistencyMode` parameter; all writes return a ZedToken string. |
 | `authorization.ts` | Authorization operations that bridge SpiceDB and the plugin: `lookupAuthorizedGroups`, `lookupViewableFragments`, `writeFragmentRelationships`, `deleteFragmentRelationships`, `canDeleteFragment`, `canWriteToGroup`, `ensureGroupMembership`. |
 | `search.ts` | Parallel multi-group search. Fans out to Graphiti (nodes + facts per group), deduplicates by UUID, ranks by recency. Also handles session vs long-term formatting. |
 | `schema.zed` | SpiceDB authorization schema (Zanzibar-style). Defines `person`, `agent`, `group`, `memory_fragment` with permissions. |
@@ -51,6 +52,35 @@ Every tool follows the same pattern:
 2. If denied, return early — never touch Graphiti
 3. If allowed, perform the Graphiti operation
 4. After Graphiti writes, record the authorization relationships in SpiceDB
+
+### ZedToken Consistency
+
+SpiceDB writes return a `ZedToken` — a causality token that guarantees subsequent reads see at least the state at the time of that write.
+
+The plugin maintains a `lastWriteToken: string | undefined` variable in `index.ts`. After any SpiceDB write (`writeRelationships`, `deleteRelationships`, `ensureGroupMembership`, `writeFragmentRelationships`, `deleteFragmentRelationships`), the token is captured. Before any SpiceDB read (`lookupAuthorizedGroups`, `canWriteToGroup`, `canDeleteFragment`), the token is passed as `atLeastAsFresh` consistency. If no prior write exists, reads use `minimizeLatency` (cheapest mode).
+
+This replaces the original `fullyConsistent` mode on all reads, which was correct but expensive (forces a quorum read). The `atLeastAsFresh` mode gives causal consistency at near-zero cost.
+
+The three consistency modes in `SpiceDbClient`:
+- `minimize_latency` — default, cheapest, may return stale data
+- `at_least_as_fresh` — causal, uses a ZedToken from a prior write
+- `full` — quorum read, most expensive, always up-to-date
+
+**E2e test pitfall**: The e2e tests also thread `lastWriteToken` through their SpiceDB calls. Without this, `lookupAuthorizedGroups` after `ensureGroupMembership` in `beforeAll` can return stale results.
+
+### Fragment Deletion
+
+`deleteFragmentRelationships` uses the filter-based `DeleteRelationships` RPC (not the tuple-based `WriteRelationships` with DELETE ops). This deletes ALL relationships where the fragment is the resource, regardless of which group it was stored to or who shared it. This is important because the caller may not know the original group or subject.
+
+### Bulk Import
+
+`bulkImportRelationships` uses the client-streaming `BulkImportRelationships` gRPC RPC. The `@authzed/authzed-node` library exposes this as a callback-based API (not promisified), so `SpiceDbClient` wraps it in a manual Promise. Falls back to batched `writeRelationships` calls if the streaming RPC is unavailable.
+
+The `graphiti-mem import` CLI uses a two-phase approach:
+1. **Phase 1**: Ingest all files/sessions to Graphiti via `addEpisode`, collecting relationship tuples
+2. **Phase 2**: Single `bulkImportRelationships` call for all collected tuples
+
+This is faster than interleaving and leaves SpiceDB clean if Graphiti fails partway (orphaned episodes are invisible without authorization — see issue #6 for cleanup tooling).
 
 ### Session Groups
 
@@ -98,12 +128,12 @@ Custom extraction instructions are prepended to `episode_body` with `[Extraction
 
 ## Testing
 
-### Unit Tests (80 tests, 5 files)
+### Unit Tests (85 tests, 5 files)
 
 All unit tests mock external dependencies — no running services needed.
 
-- `index.test.ts` (18 tests) — Plugin integration: tool execution, hooks, CLI, authorization enforcement. Mocks both `@authzed/authzed-node` (via `vi.mock`) and `fetch` (for Graphiti MCP).
-- `authorization.test.ts` (10 tests) — Authorization functions with mocked SpiceDB client.
+- `index.test.ts` (19 tests) — Plugin integration: tool execution, hooks, CLI, authorization enforcement, ZedToken threading. Mocks both `@authzed/authzed-node` (via `vi.mock`) and `fetch` (for Graphiti MCP).
+- `authorization.test.ts` (14 tests) — Authorization functions with mocked SpiceDB client. Includes consistency mode verification.
 - `search.test.ts` (16 tests) — Parallel search, dedup, formatting with mocked Graphiti client.
 - `graphiti.test.ts` (21 tests) — Graphiti MCP client with mocked fetch (SSE parsing, session handling).
 - `config.test.ts` (15 tests) — Config parsing, defaults, env var resolution, validation.
@@ -111,11 +141,15 @@ All unit tests mock external dependencies — no running services needed.
 ### E2E Tests (13 tests, 1 file)
 
 `e2e.test.ts` runs against real SpiceDB + Graphiti + FalkorDB. Requires:
-- Docker services running (`docker compose up -d falkordb graphiti-mcp spicedb`)
-- `OPENAI_API_KEY` in environment
+- Services running natively (dev container) or via Docker
+- `OPENAI_API_KEY` in environment (can be dummy `1` value for test runner — Graphiti needs it set)
 - `OPENCLAW_LIVE_TEST=1` to enable
 
 Tests are skipped automatically when `OPENCLAW_LIVE_TEST` is not set.
+
+**Important**: Run e2e tests from the plugin directory, not the parent workspace. Running from the parent will pick up all `*.test.ts` files across workspaces.
+
+The dev container SpiceDB token is `dev_token` (configured in OpenClaw plugin config). The e2e tests use `testtoken` (hardcoded in `e2e.test.ts`).
 
 ### Test Pitfalls
 
@@ -129,6 +163,8 @@ beforeEach(async () => {
   const mockClient = (v1.NewClient as ReturnType<typeof vi.fn>)();
   mockClient.promises.checkPermission.mockResolvedValue({ permissionship: 2 });
   mockClient.promises.lookupResources.mockResolvedValue([{ resourceObjectId: "main" }]);
+  mockClient.promises.writeRelationships.mockResolvedValue({ writtenAt: { token: "write-token-1" } });
+  mockClient.promises.deleteRelationships.mockResolvedValue({ deletedAt: { token: "delete-token" } });
 });
 ```
 
@@ -157,7 +193,8 @@ beforeEach(async () => {
 - No build step — OpenClaw loads `.ts` files directly.
 - Strict TypeScript (`"strict": true`).
 - Tests use Vitest. Test files are co-located with source (`*.test.ts`).
-- Dependencies: `@authzed/authzed-node` (SpiceDB gRPC), `@sinclair/typebox` (tool parameter schemas).
+- Dependencies: `@authzed/authzed-node` v1.6.1 (SpiceDB gRPC), `@sinclair/typebox` (tool parameter schemas).
+- When exploring `@authzed/authzed-node` APIs, use DeepWiki MCP (`ask_question` on `authzed/authzed-node`) or check the library's own tests at `node_modules/@authzed/authzed-node/src/v1-promise.test.ts` for usage patterns. Some streaming RPCs (like `bulkImportRelationships`) are callback-based, not promisified.
 - The `openclaw/plugin-sdk` import is resolved from the parent monorepo (or via `OPENCLAW_ROOT` env var for standalone dev, configured in `vitest.config.ts`).
 
 ## The `.dev/` Directory

--- a/graphiti.test.ts
+++ b/graphiti.test.ts
@@ -106,7 +106,7 @@ describe("GraphitiClient", () => {
     expect(initCall[0]).toBe("http://localhost:8000/mcp");
     const initBody = JSON.parse(initCall[1]!.body as string);
     expect(initBody.method).toBe("initialize");
-    expect(initBody.params.clientInfo.name).toBe("openclaw-memory-graphiti");
+    expect(initBody.params.clientInfo.name).toBe("memory-graphiti");
 
     // Second call: notifications/initialized
     const notifCall = fetchMock.mock.calls[1];

--- a/graphiti.ts
+++ b/graphiti.ts
@@ -96,7 +96,7 @@ export class GraphitiClient {
       params: {
         protocolVersion: "2025-11-25",
         capabilities: {},
-        clientInfo: { name: "openclaw-memory-graphiti", version: "1.0.0" },
+        clientInfo: { name: "memory-graphiti", version: "1.0.0" },
       },
     };
 


### PR DESCRIPTION
## Summary
- Fix `clientInfo.name` in `graphiti.ts` from `"openclaw-memory-graphiti"` to `"memory-graphiti"` to match the manifest-defined plugin id, eliminating the gateway config warning
- Update corresponding test assertion in `graphiti.test.ts`
- Include `CLAUDE.md` documentation updates missed in previous PRs (ZedToken consistency, bulk import, filter-based delete)

Closes #9

## Test plan
- [x] All 85 unit tests pass (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)