### PR TITLE
Fix plugin id mismatch by emptying openclaw.extensions

### DIFF
--- a/graphiti.test.ts
+++ b/graphiti.test.ts
@@ -106,7 +106,7 @@ describe("GraphitiClient", () => {
     expect(initCall[0]).toBe("http://localhost:8000/mcp");
     const initBody = JSON.parse(initCall[1]!.body as string);
     expect(initBody.method).toBe("initialize");
-    expect(initBody.params.clientInfo.name).toBe("memory-graphiti");
+    expect(initBody.params.clientInfo.name).toBe("openclaw-memory-graphiti");
 
     // Second call: notifications/initialized
     const notifCall = fetchMock.mock.calls[1];

--- a/graphiti.ts
+++ b/graphiti.ts
@@ -96,7 +96,7 @@ export class GraphitiClient {
       params: {
         protocolVersion: "2025-11-25",
         capabilities: {},
-        clientInfo: { name: "memory-graphiti", version: "1.0.0" },
+        clientInfo: { name: "openclaw-memory-graphiti", version: "1.0.0" },
       },
     };
 

--- a/package.json
+++ b/package.json
@@ -44,9 +44,8 @@
     "access": "public"
   },
   "openclaw": {
-    "extensions": [
-      "./index.ts"
-    ],
+    "_extensions_note": "Intentionally empty — explicit entries cause idHint to derive from the npm package name rather than the directory name, producing a mismatch with the manifest id. Previously: [\"./index.ts\"]",
+    "extensions": [],
     "install": {
       "npmSpec": "@contextableai/openclaw-memory-graphiti",
       "localPath": "extensions/memory-graphiti",


### PR DESCRIPTION
## Summary
- Empty `openclaw.extensions` in `package.json` so the gateway's plugin discovery falls through to index file detection, which derives the idHint from the directory name rather than the unscoped npm package name (`openclaw-memory-graphiti`). This matches the manifest id (`memory-graphiti`).
- Revert the `clientInfo.name` change from #10 — that was unrelated to the gateway warning.

Closes #9

## Test plan
- [x] All 85 unit tests pass (`npx vitest run`)
- [x] Verified the gateway no longer logs the `plugin id mismatch` warning on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)