### PR TITLE
feat: add unused MCP tools and search parameters

### DIFF
--- a/search.test.ts
+++ b/search.test.ts
@@ -17,6 +17,10 @@ function mockGraphiti(overrides?: Partial<GraphitiClient>): GraphitiClient {
     deleteEpisode: vi.fn().mockResolvedValue(undefined),
     searchNodes: vi.fn().mockResolvedValue([]),
     searchFacts: vi.fn().mockResolvedValue([]),
+    getEntityEdge: vi.fn().mockResolvedValue({}),
+    deleteEntityEdge: vi.fn().mockResolvedValue(undefined),
+    clearGraph: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as GraphitiClient;
 }
@@ -151,6 +155,38 @@ describe("searchAuthorizedMemories", () => {
 
     expect(searchNodes).toHaveBeenCalledTimes(1);
     expect(searchFacts).not.toHaveBeenCalled();
+  });
+
+  test("forwards entityTypes to searchNodes calls", async () => {
+    const searchNodes = vi.fn().mockResolvedValue([]);
+    const searchFacts = vi.fn().mockResolvedValue([]);
+    const graphiti = mockGraphiti({ searchNodes, searchFacts });
+
+    await searchAuthorizedMemories(graphiti, {
+      query: "test",
+      groupIds: ["g1"],
+      entityTypes: ["Preference", "Organization"],
+    });
+
+    expect(searchNodes).toHaveBeenCalledWith(
+      expect.objectContaining({ entity_types: ["Preference", "Organization"] }),
+    );
+  });
+
+  test("forwards centerNodeUuid to searchFacts calls", async () => {
+    const searchNodes = vi.fn().mockResolvedValue([]);
+    const searchFacts = vi.fn().mockResolvedValue([]);
+    const graphiti = mockGraphiti({ searchNodes, searchFacts });
+
+    await searchAuthorizedMemories(graphiti, {
+      query: "test",
+      groupIds: ["g1"],
+      centerNodeUuid: "node-uuid-123",
+    });
+
+    expect(searchFacts).toHaveBeenCalledWith(
+      expect.objectContaining({ center_node_uuid: "node-uuid-123" }),
+    );
   });
 });
 

--- a/search.ts
+++ b/search.ts
@@ -27,6 +27,8 @@ export type SearchOptions = {
   limit?: number;
   searchNodes?: boolean;
   searchFacts?: boolean;
+  entityTypes?: string[];
+  centerNodeUuid?: string;
 };
 
 // ============================================================================
@@ -41,7 +43,15 @@ export async function searchAuthorizedMemories(
   graphiti: GraphitiClient,
   options: SearchOptions,
 ): Promise<SearchResult[]> {
-  const { query, groupIds, limit = 10, searchNodes = true, searchFacts = true } = options;
+  const {
+    query,
+    groupIds,
+    limit = 10,
+    searchNodes = true,
+    searchFacts = true,
+    entityTypes,
+    centerNodeUuid,
+  } = options;
 
   if (groupIds.length === 0) {
     return [];
@@ -52,10 +62,10 @@ export async function searchAuthorizedMemories(
 
   for (const groupId of groupIds) {
     if (searchNodes) {
-      promises.push(searchNodesForGroup(graphiti, query, groupId, limit));
+      promises.push(searchNodesForGroup(graphiti, query, groupId, limit, entityTypes));
     }
     if (searchFacts) {
-      promises.push(searchFactsForGroup(graphiti, query, groupId, limit));
+      promises.push(searchFactsForGroup(graphiti, query, groupId, limit, centerNodeUuid));
     }
   }
 
@@ -99,8 +109,9 @@ async function searchNodesForGroup(
   query: string,
   groupId: string,
   limit: number,
+  entityTypes?: string[],
 ): Promise<SearchResult[]> {
-  const nodes = await graphiti.searchNodes({ query, group_id: groupId, limit });
+  const nodes = await graphiti.searchNodes({ query, group_id: groupId, limit, entity_types: entityTypes });
   return nodes.map(nodeToResult);
 }
 
@@ -109,8 +120,9 @@ async function searchFactsForGroup(
   query: string,
   groupId: string,
   limit: number,
+  centerNodeUuid?: string,
 ): Promise<SearchResult[]> {
-  const facts = await graphiti.searchFacts({ query, group_id: groupId, limit });
+  const facts = await graphiti.searchFacts({ query, group_id: groupId, limit, center_node_uuid: centerNodeUuid });
   return facts.map(factToResult);
 }
 


### PR DESCRIPTION
## Summary
- Add 3 new `GraphitiClient` methods: `getEntityEdge`, `deleteEntityEdge`, `clearGraph` — wrapping the 3 previously unused Graphiti MCP server tools
- Add `entity_types` parameter to `searchNodes` — filters results by entity classification (Preference, Organization, etc.)
- Add `center_node_uuid` parameter to `searchFacts` — anchors fact search around a specific entity
- Thread both new params through `search.ts` helpers and expose on the `memory_recall` tool in `index.ts`
- Fix flaky e2e "batch conversation capture" test by polling for extraction results instead of fixed sleep

## Test plan
- [x] 9 new unit tests (7 in graphiti.test.ts, 2 in search.test.ts) — all 105 unit tests pass
- [x] 13 e2e tests pass against live MCP server (including previously flaky batch capture test)
- [x] Verified `entity_types` forwarding to `search_nodes` tool args
- [x] Verified `center_node_uuid` forwarding to `search_memory_facts` tool args
- [x] Verified `getEntityEdge` uses `parseJsonResult` (not `parseToolResult`) for single-object response
- [x] Verified `clearGraph` omits `group_ids` when called without args

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)