### PR TITLE
feat: add fact and clear-graph CLI commands

### DIFF
--- a/cli.test.ts
+++ b/cli.test.ts
@@ -65,7 +65,7 @@ function createMockContext(): CliContext {
 // ============================================================================
 
 describe("registerCommands", () => {
-  test("registers all 8 subcommands on the passed-in command", () => {
+  test("registers all 10 subcommands on the passed-in command", () => {
     const { program, commands } = createMockProgram();
     const ctx = createMockContext();
 
@@ -78,8 +78,10 @@ describe("registerCommands", () => {
     expect(commands).toContain("groups");
     expect(commands).toContain("add-member");
     expect(commands).toContain("cleanup");
+    expect(commands).toContain("fact");
+    expect(commands).toContain("clear-graph");
     expect(commands).toContain("import");
-    expect(commands).toHaveLength(8);
+    expect(commands).toHaveLength(10);
   });
 
   test("registers action handlers for all subcommands", () => {
@@ -95,6 +97,8 @@ describe("registerCommands", () => {
     expect(typeof actions["groups"]).toBe("function");
     expect(typeof actions["add-member"]).toBe("function");
     expect(typeof actions["cleanup"]).toBe("function");
+    expect(typeof actions["fact"]).toBe("function");
+    expect(typeof actions["clear-graph"]).toBe("function");
     expect(typeof actions["import"]).toBe("function");
   });
 

--- a/cli.ts
+++ b/cli.ts
@@ -205,6 +205,47 @@ export function registerCommands(cmd: Command, ctx: CliContext): void {
     });
 
   cmd
+    .command("fact")
+    .description("Get a specific fact (entity edge) by UUID")
+    .argument("<uuid>", "Fact UUID")
+    .action(async (uuid: string) => {
+      try {
+        const fact = await graphiti.getEntityEdge(uuid);
+        console.log(JSON.stringify(fact, null, 2));
+      } catch (err) {
+        console.error(`Failed to get fact ${uuid}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  cmd
+    .command("clear-graph")
+    .description("Clear graph data for specified groups (destructive!)")
+    .option("--group <id...>", "Group ID(s) to clear")
+    .option("--confirm", "Required safety flag to confirm the operation", false)
+    .action(async (opts: { group?: string[]; confirm: boolean }) => {
+      if (!opts.confirm) {
+        console.log("This is a destructive operation. Pass --confirm to proceed.");
+        if (opts.group && opts.group.length > 0) {
+          console.log(`Would clear graph data for groups: ${opts.group.join(", ")}`);
+        } else {
+          console.log("Would clear the default group's graph data.");
+        }
+        return;
+      }
+
+      try {
+        await graphiti.clearGraph(opts.group);
+        if (opts.group && opts.group.length > 0) {
+          console.log(`Graph data cleared for groups: ${opts.group.join(", ")}`);
+        } else {
+          console.log("Graph data cleared for default group.");
+        }
+      } catch (err) {
+        console.error(`Failed to clear graph: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    });
+
+  cmd
     .command("import")
     .description("Import workspace markdown files (and optionally session transcripts) into Graphiti")
     .option("--workspace <path>", "Workspace directory", join(homedir(), ".openclaw", "workspace"))


### PR DESCRIPTION
## Summary
- Add `graphiti-mem fact <uuid>` — fetch and display a specific fact (entity edge) by UUID as JSON
- Add `graphiti-mem clear-graph [--group <id...>] [--confirm]` — clear graph data for specified groups with safety gate (`--confirm` required)
- Not exposed as agent-callable tools — CLI only

## Test plan
- [x] `fact` and `clear-graph` registered as subcommands (updated cli.test.ts: 8 → 10 commands)
- [x] Action handlers registered for both new commands
- [x] All 108 unit tests pass

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)