### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,35 @@
 # Changelog
 
-## Unreleased
+## 0.2.0 - 2026-02-11
 
 ### Added
 
+- `getEntityEdge`, `deleteEntityEdge`, and `clearGraph` methods on `GraphitiClient` — wrapping the previously unused `get_entity_edge`, `delete_entity_edge`, and `clear_graph` MCP server tools
+- `entity_types` filter parameter on `searchNodes` — filters results by entity classification (e.g. Preference, Organization, Procedure)
+- `center_node_uuid` parameter on `searchFacts` — anchors fact search around a specific entity node ("tell me everything about X")
+- `entity_types` and `center_node_uuid` optional parameters on the `memory_recall` agent tool, threaded through to Graphiti search calls
+- `memory_forget` now supports deleting individual facts via a new `fact_id` parameter — fetches the fact to determine its `group_id`, checks `canWriteToGroup` authorization, then deletes the entity edge
+- `graphiti-mem fact <uuid>` CLI command — fetch and display a specific fact (entity edge) by UUID as JSON
+- `graphiti-mem clear-graph` CLI command — clear graph data for specified groups; requires `--confirm` safety flag, supports `--group <id...>` to target specific groups
 - `graphiti-mem cleanup` CLI command to find and optionally delete orphaned Graphiti episodes — episodes that exist in Graphiti but have no `source_group` relationship in SpiceDB (can happen when Phase 2 of a two-phase import fails). Supports `--group`, `--last`, `--delete`, and `--dry-run` flags.
 - `readRelationships` method on `SpiceDbClient` for querying existing authorization tuples by resource type, relation, and subject filter
 - Bulk import: `graphiti-mem import` now uses two-phase approach — Graphiti ingestion first, then a single `BulkImportRelationships` streaming RPC to SpiceDB (with batched `WriteRelationships` fallback), replacing per-file interleaved writes
 - ZedToken consistency tuning: SpiceDB reads after writes now use `at_least_as_fresh` consistency with the token from the preceding write, ensuring causal consistency without the cost of `fully_consistent`; reads without a prior write use `minimize_latency` for optimal performance
 
+### Changed
+
+- `memory_forget` tool: `episode_id` is now optional — callers must provide either `episode_id` or `fact_id` (not both)
+- Docker image updated from stale `ghcr.io/getzep/graphiti-mcp:latest` to `zepai/knowledge-graph-mcp:latest`, matching the upstream Graphiti project's published image
+
 ### Fixed
 
 - **UUID mismatch between Graphiti and SpiceDB**: `addEpisode` now polls `getEpisodes` in the background to resolve the real server-side UUID assigned by Graphiti (the MCP `add_memory` tool only returns a "queued" message, not the UUID). SpiceDB authorization relationships are written with the real UUID once resolved, fixing broken fragment-level authorization (`memory_forget`, `canDeleteFragment`, `lookupViewableFragments`). The polling is non-blocking — `memory_store` and auto-capture return immediately while SpiceDB writes happen in the background; `graphiti-mem import` awaits all UUIDs before Phase 2 bulk write.
 - `memory_forget` now uses filter-based `DeleteRelationships` RPC to clean up SpiceDB relationships, fixing orphaned tuples when deleting fragments stored to non-default groups or by other subjects
+- Flaky "batch conversation capture extracts entities" E2E test — replaced fixed 20s sleep with a polling loop (up to 8 attempts at 5s intervals) to handle variable Graphiti extraction queue latency
+
+### Internal
+
+- Extracted `mcpUrl` getter in `GraphitiClient` for single-point trailing slash adjustment across all 4 MCP endpoint references
 
 ## 0.1.2 - 2026-02-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/openclaw-memory-graphiti",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "OpenClaw two-layer memory plugin: SpiceDB authorization + Graphiti knowledge graph",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bumps version from 0.1.2 to 0.2.0
- Updates CHANGELOG.md with all Phase 1 Graphiti capabilities expansion entries (PRs #19–#23)

### Changelog highlights

**Added:** 3 new `GraphitiClient` methods (`getEntityEdge`, `deleteEntityEdge`, `clearGraph`), `entity_types` and `center_node_uuid` search parameters on `memory_recall`, fact deletion via `fact_id` on `memory_forget`, `graphiti-mem fact` and `graphiti-mem clear-graph` CLI commands

**Changed:** `memory_forget` `episode_id` now optional, Docker image updated to `zepai/knowledge-graph-mcp:latest`

**Fixed:** Graphiti/SpiceDB UUID mismatch, orphaned SpiceDB tuples on delete, flaky E2E test

## Test plan

- [ ] Verify `package.json` version is `0.2.0`
- [ ] Verify CHANGELOG entries match merged PRs #19–#23
- [ ] `npm publish --dry-run` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)